### PR TITLE
regexp point wasn't validated

### DIFF
--- a/sentence_parser/sentence.js
+++ b/sentence_parser/sentence.js
@@ -1,4 +1,3 @@
-
 var sentenceparser = (function() {
 
 //by spencer kelly (@spencermountain)
@@ -151,7 +150,7 @@ var sentenceparser=function(text) {
     ]
 
 
-    var abbrev=new RegExp("(^| )("+abbrevs.join("|")+")\. ?$","i");
+    var abbrev=new RegExp("(^| )("+abbrevs.join("|")+")[.] ?$","i");
     //join acronyms, titles
     for (var i in tmp) {
         if (tmp[i]) {


### PR DESCRIPTION
in a string type RegExp, the '.' is considered as a . meaning any character, which generated unwanted results for phrases like "i like that color" where "Colo" is an abrev and 'r' is considered a joker character.

The . should be replaced with a \. or a [.] to be considered as a normal point character.
