### PR TITLE
Removed duplicate declaration

### DIFF
--- a/src/sentence/pos/parts_of_speech.js
+++ b/src/sentence/pos/parts_of_speech.js
@@ -67,7 +67,6 @@ const classMapping = {
   'PresentTense': Verb,
   'FutureTense': Verb,
   'PastTense': Verb,
-  'PresentTense': Verb,
   'Infinitive': Verb,
   'PerfectTense': Verb,
   'PluperfectTense': Verb,


### PR DESCRIPTION
Strict mode throws a tantrum for the duplicate declaration:

```SyntaxError: Duplicate data property in object literal not allowed in strict mode```

Removed the duplicate declaration to avoid build errors in tools like babel etc.