### PR TITLE
Fix whitespace bug when expanding contractions

### DIFF
--- a/src/sentence/contractions/interpret.js
+++ b/src/sentence/contractions/interpret.js
@@ -51,6 +51,7 @@ const handle_simple = function(terms, i, particle) {
   //make ghost-term
   let second_word = new pos.Verb('');
   second_word.expansion = particle;
+  second_word.whitespace.trailing = ' ';
   terms.splice(i + 1, 0, second_word);
   return terms;
 };

--- a/test/unit_tests/sentence/contractions_test.js
+++ b/test/unit_tests/sentence/contractions_test.js
@@ -99,4 +99,11 @@ describe('contractions', function() {
     done();
   });
 
+  it('outputs correct whitespace', function() {
+   let test = ['We\'ve only just begun', 'We have only just begun'];
+   let t = nlp.text(test[0]);
+   t.contractions.expand()
+   t.text().should.equal(test[1]);
+  })
+
 });


### PR DESCRIPTION
On the website demos:
https://github.com/nlp-compromise/website/blob/gh-pages/demos/demos.jsx#L211

The sentence:

We've only just begun, to live. White lace and promises. We'll start out
walkin' and learn to run.

is incorrectly expanded to:

We haveonly just begun, to live. White lace and promises. We willstart
out walkin' and learn to run.

(notice the whitespace errors). This commit adds trailing whitespace to
the expanded verbs resulting in:

We have only just begun, to live. White lace and promises. We will start
out walkin' and learn to run.

Added regression test.