### PR TITLE
document the case of names that do not signal gender

### DIFF
--- a/src/term/noun/person/gender.js
+++ b/src/term/noun/person/gender.js
@@ -38,9 +38,11 @@ const gender = function(normal) {
   if (firstName.match(/(nn|ll|tt)/i)) { //if it has double-consonants, female
     return 'Female';
   }
+  // name not recognized, or recognized as of indeterminate gender
   return null;
 };
 module.exports = gender;
 
 // console.log(gender('john', 'john') === 'Male');
 // console.log(gender('jane smith', 'jane') === 'Female');
+// console.log(gender('jan smith', 'jan') === null);


### PR DESCRIPTION
As noted in #117 the software attempts to guess the gender of names. The internal and external documentation should show that three gender values are defined: 'Male', 'Female', and null.