### PR TITLE
[WIP] Whitelist production files

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,10 @@
     "watch": "grunt watch",
     "build": "grunt build"
   },
+  "files": [
+    "builds/",
+    "src/"
+  ],
   "dependencies": {},
   "devDependencies": {
     "babel-preset-es2015": "6.3.13",


### PR DESCRIPTION
Fixes #121.

WIP because I have a few questions:

* Is the `plugins/` directory needed?
* The main entry point for this module is the unminified build file generated by grunt. That means the user does not run any code under the `src/` directory. There's two choices here: Only whitelist `builds/` or make `src/index.js` the main entry point.