### PR TITLE
Fix sentence.replace() which fails on not found terms

### DIFF
--- a/src/match/match.js
+++ b/src/match/match.js
@@ -89,9 +89,11 @@ const findAll = function(terms, regs, options) {
 //calls Terms.replace() on each found result
 const replaceAll = function(terms, regs, replacement, options) {
   let list = findAll(terms, regs, options);
-  list.forEach((t) => {
-    t.replace(replacement, options);
-  });
+  if (list) {
+    list.forEach((t) => {
+      t.replace(replacement, options);
+    });
+  }
 };
 
 

--- a/test/unit_tests/match/match_test.js
+++ b/test/unit_tests/match/match_test.js
@@ -92,7 +92,8 @@ describe('replace', function() {
     ['the dog played', 'the dog', 'the cat', 'the cat played'],
     ['the dog played', 'the [Noun]', 'the cat', 'the cat played'],
     ['the dog played', 'the (dog|hamster|pet-snake)', 'the cat', 'the cat played'],
-    ['the boy and the girl', 'the [Noun]', 'the house', 'the house and the house']
+    ['the boy and the girl', 'the [Noun]', 'the house', 'the house and the house'],
+    ['the boy and the girl', 'the cat', 'the house', 'the boy and the girl'],
   ];
   tests.forEach(function(a) {
     it(a.join(' | '), function(done) {


### PR DESCRIPTION
Minor fix to protect from `TypeError: Cannot read property 'forEach' of null`.

Reproducing test included:

```js
['the boy and the girl', 'the cat', 'the house', 'the boy and the girl']
```
