### PR TITLE
Add HUF as a currency.

### DIFF
--- a/src/term/noun/value/units.js
+++ b/src/term/noun/value/units.js
@@ -152,6 +152,7 @@ const units = {
     'won': 'currency',
     'krona': 'currency',
     'dirham': 'currency',
+    'forint': 'currency',
     '€': 'currency',
     '$': 'currency',
     '¥': 'currency',
@@ -164,6 +165,7 @@ const units = {
     'EUR': 'currency',
     'CNY': 'currency',
     'EGP': 'currency',
+    'HUF': 'currency',
     'MXN': 'currency'
   }
 };


### PR DESCRIPTION
The ISO code HUF is used when referring to the Hungarian currency, forint.
Added that as a Currency Unit.