### PR TITLE
Fix actor for 'stream' (vb.)

### DIFF
--- a/src/data/irregular_verbs.js
+++ b/src/data/irregular_verbs.js
@@ -285,6 +285,9 @@ const irregular_verbs = {
   sting: {
     past: 'stung'
   },
+  stream: {
+    actor: 'streamer'
+  },
   strike: {
     gerund: 'striking',
     past: 'struck'


### PR DESCRIPTION
- [x] Fixes "streammer" as actor for "to stream"

Thought I’d make a pull request this time (compared to [last time](https://github.com/nlp-compromise/nlp_compromise/issues/143)).

Hope this is the right way to contribute.

<3