### PR TITLE
Add grunt-cli dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "natural language processing in the browser",
   "version": "6.1.2",
   "main": "./builds/nlp_compromise.js",
-  "browser":"./src/index.js",
+  "browser": "./src/index.js",
   "typings": "./nlp.d.ts",
   "repository": {
     "type": "git",
@@ -31,6 +31,7 @@
     "browserify": "13.0.0",
     "grunt": "0.4.5",
     "grunt-bump": "^0.7.0",
+    "grunt-cli": "^1.2.0",
     "grunt-contrib-uglify": "^0.11.0",
     "grunt-contrib-watch": "0.6.1",
     "grunt-eslint": "^18.0.0",


### PR DESCRIPTION
This allows use of the `npm` run scripts (or even just grunt directly) without having grunt-cli installed globally. 

This is also what the [grunt repo recommends](https://github.com/gruntjs/grunt-cli):

> **Note:** The job of the grunt command is to load and run the version of Grunt you have installed locally to your project, irrespective of its version. Starting with Grunt v0.4, you should never install Grunt itself globally. For more information about why, [please read this](http://nodejs.org/en/blog/npm/npm-1-0-global-vs-local-installation).

