### PR TITLE
join slack link added

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ sen.terms[1].links[1].target.word; // terms[1] is verb 'fed'
 
 *Useful NLP is a problem only solved with many hands. [Contributing](https://github.com/nlp-compromise/nlp_compromise/blob/master/contributing.md) in any form is valued.*
 
-Join our [slack group](https://superscriptjs.slack.com/messages/nlp_compromise/) or our infrequent [announcement email-list](http://eepurl.com/bL9YRv).
+Join our [slack group](http://superscript-slackin.herokuapp.com) (login from [here](https://superscriptjs.slack.com/messages/nlp_compromise/)) or our infrequent [announcement email-list](http://eepurl.com/bL9YRv).
 
 Or just pick up an [open issue](https://github.com/nlp-compromise/nlp_compromise/issues)
 


### PR DESCRIPTION
Resolves #125, the current slack link was redirecting to login page of the slack group and was not redirecting to the join group page. Modified it after getting the slack link from issue #125.