### PR TITLE
Correctly detect acronyms with 2 or more letters

### DIFF
--- a/src/term/is_acronym.js
+++ b/src/term/is_acronym.js
@@ -5,7 +5,7 @@ const is_acronym = function(str) {
     return true;
   }
   //like NDA
-  if (str.match(/[A-Z]{3}$/)) {
+  if (str.match(/[A-Z]{2,}$/)) {
     return true;
   }
   return false;


### PR DESCRIPTION
This change updates the match to correctly detect acronyms that are made up of only 2 letters, such as UN, EU, AA, etc.