### PR TITLE
term.toTextNumber() now works with positive numbers

### DIFF
--- a/src/result/index.js
+++ b/src/result/index.js
@@ -65,3 +65,7 @@ const People = require('./people');
 Result.prototype.people = function() {
   return new People(this.list);
 };
+
+Result.prototype.toTextNumber = function() {
+  return new Values(this.list).toTextValue()
+}

--- a/src/term/index.js
+++ b/src/term/index.js
@@ -27,7 +27,6 @@ class Term {
     bindMethods(require('./adjective'), 'adjective', this);
     bindMethods(require('./value'), 'value', this);
     bindMethods(require('./pronoun'), 'pronoun', this);
-
     bindMethods(require('./render'), 'render', this);
 
     this.normalize();

--- a/test/unit/value.test.js
+++ b/test/unit/value.test.js
@@ -93,38 +93,38 @@ test('==Value==', function(T) {
   //   t.end();
   // });
 
-  // T.test('to_text:', function(t) {
-  //   [
-  //     // [-5, 'negative five'],
-  //     [5, 'five'],
-  //     [15, 'fifteen'],
-  //     [10, 'ten'],
-  //     [20, 'twenty'],
-  //     [75, 'seventy five'],
-  //     [97, 'ninety seven'],
-  //     [111, 'one hundred and eleven'],
-  //     [175, 'one hundred and seventy five'],
-  //     [900, 'nine hundred'],
-  //     [1175, 'one thousand one hundred and seventy five'],
-  //     [2000, 'two thousand'],
-  //     [2100, 'two thousand one hundred'],
-  //     [2102, 'two thousand one hundred and two'],
-  //     [70000, 'seventy thousand'],
-  //     [72000, 'seventy two thousand'],
-  //     [900000, 'nine hundred thousand'],
-  //     [900001, 'nine hundred thousand and one'],
-  //     [900200, 'nine hundred thousand two hundred'],
-  //     [900205, 'nine hundred thousand two hundred and five'],
-  //     [7900205, 'seven million nine hundred thousand two hundred and five'],
-  //     [90000000, 'ninety million'],
-  //     [900000000, 'nine hundred million'],
-  //     [900000080, 'nine hundred million and eighty'],
-  //   ].forEach(function (a) {
-  //     var str = nlp(a[0]).toTextNumber().normal();
-  //     str_test(str, a[0], a[1], t);
-  //   });
-  //   t.end();
-  // });
+  T.test('to_text:', function(t) {
+    [
+      // [-5, 'negative five'],
+      [5, 'five'],
+      [15, 'fifteen'],
+      [10, 'ten'],
+      [20, 'twenty'],
+      [75, 'seventy five'],
+      [97, 'ninety seven'],
+      [111, 'one hundred and eleven'],
+      [175, 'one hundred and seventy five'],
+      [900, 'nine hundred'],
+      [1175, 'one thousand one hundred and seventy five'],
+      [2000, 'two thousand'],
+      [2100, 'two thousand one hundred'],
+      [2102, 'two thousand one hundred and two'],
+      [70000, 'seventy thousand'],
+      [72000, 'seventy two thousand'],
+      [900000, 'nine hundred thousand'],
+      [900001, 'nine hundred thousand and one'],
+      [900200, 'nine hundred thousand two hundred'],
+      [900205, 'nine hundred thousand two hundred and five'],
+      [7900205, 'seven million nine hundred thousand two hundred and five'],
+      [90000000, 'ninety million'],
+      [900000000, 'nine hundred million'],
+      [900000080, 'nine hundred million and eighty'],
+    ].forEach(function (a) {
+      var str = nlp(a[0]).toTextNumber().normal();
+      str_test(str, a[0], a[1], t);
+    });
+    t.end();
+  });
 
 
   T.test('to_number:', function(t) {


### PR DESCRIPTION
We can now call toTextNumber directly off of a term.  All test related to toTextNumber except for the commented out -5 are passing.