### PR TITLE
fix(verb) Fix for issue #302: The word invest/ invested is not recognized as a verb

### DIFF
--- a/src/data/verbs/verbs.js
+++ b/src/data/verbs/verbs.js
@@ -153,6 +153,7 @@ let arr = [
   'hope',
   'include',
   'instruct',
+  'invest',
   'join',
   'keep',
   'know',

--- a/test/unit/tagger/tagger.test.js
+++ b/test/unit/tagger/tagger.test.js
@@ -55,6 +55,8 @@ test('pos from-lexicon', function (t) {
     ['823-425-1231', 'PhoneNumber'],
     ['823 425-1231', 'PhoneNumber'],
     ['(823) 425-1231', 'PhoneNumber'],
+    ['invest', 'Verb'],
+    ['investing', 'Verb'],
   ];
   arr.forEach(function (a) {
     var term = nlp(a[0]).list[0].terms[0];

--- a/test/unit/verb/conjugate.test.js
+++ b/test/unit/verb/conjugate.test.js
@@ -170,6 +170,11 @@ var arr = [
     'PresentTense': 'fuzzes',
     'PastTense': 'fuzzed',
     'Gerund': 'fuzzing',
+  }, {
+    'Infinitive': 'invest',
+    'PresentTense': 'invests',
+    'PastTense': 'invested',
+    'Gerund': 'investing'
   }
 ];
 test('conjugation:', function(t) {


### PR DESCRIPTION
Include 'invest' as a verb in the data. Add additional unit tests to show that invest is treated as a verb.