### PR TITLE
Switch from declare module to declare namespace for tsgo support

### DIFF
--- a/types/one.d.ts
+++ b/types/one.d.ts
@@ -5,7 +5,7 @@ import type View from './view/one.d.ts'
 declare function nlp(text: string, lexicon?: Lexicon): View
 
 // Constructor
-declare module nlp {
+declare namespace nlp {
   /** interpret text without tagging */
   export function tokenize(text: string, lexicon?: Lexicon): View
   /** scan through text with minimal analysis */

--- a/types/three.d.ts
+++ b/types/three.d.ts
@@ -5,7 +5,7 @@ import type View from './view/three.d.ts'
 declare function nlp<PluginTypes = {}>(text: string, lexicon?: Lexicon): View & PluginTypes
 
 // Constructor
-declare module nlp {
+declare namespace nlp {
   /** interpret text without tagging */
   export function tokenize(text: string, lexicon?: Lexicon): View
   /** scan through text with minimal analysis */

--- a/types/two.d.ts
+++ b/types/two.d.ts
@@ -5,7 +5,7 @@ import type View from './view/two.d.ts'
 declare function nlp(text: string, lexicon?: Lexicon): View
 
 // Constructor
-declare module nlp {
+declare namespace nlp {
   /** interpret text without tagging */
   export function tokenize(text: string, lexicon?: Lexicon): View
   /** scan through text with minimal analysis */


### PR DESCRIPTION
This PR allows folks using the nightly builds of tsgo to be able to use the lib

The term 'modules' in .d.ts files is pretty old (it had it's [hey-day in TS 1.5](https://www.typescriptlang.org/docs/handbook/namespaces.html)) and now the new version of TypeScript built in go (7) is dropping support for the old `module` -> `namespace`  alias which was baked into the compiler