### PR TITLE
ci(release): protect against cache poisoning

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,7 @@ jobs:
       - uses: actions/setup-node@v4
         with: 
           node-version: 'lts/*'
+          package-manager-cache: false
           registry-url: 'https://registry.npmjs.org'
 
       - name: install


### PR DESCRIPTION
Disabled caching for the release workflow to prevent cache poisoning, as suggested in the [actions/setup-node docs](https://github.com/actions/setup-node?tab=readme-ov-file#breaking-changes-in-v5). [This was what hit TanStack](https://tanstack.com/blog/npm-supply-chain-compromise-postmortem).

Caching may need to be disabled in the other workflows.


