### PR TITLE
feat(fractions): add toText() method

### DIFF
--- a/src/3-three/numbers/fractions/api.js
+++ b/src/3-three/numbers/fractions/api.js
@@ -64,6 +64,17 @@ const plugin = function (View) {
       })
       return this
     }
+    // spell it out - '1/2' -> 'one half'
+    toText(n) {
+      this.getNth(n).forEach(m => {
+        const obj = parse(m)
+        const str = toOrdinal(obj)
+        if (str) {
+          m.replaceWith(str)
+        }
+      })
+      return this
+    }
     toPercentage(n) {
       this.getNth(n).forEach(m => {
         const { decimal } = parse(m)

--- a/tests/three/numbers/fractions.test.js
+++ b/tests/three/numbers/fractions.test.js
@@ -117,6 +117,21 @@ test('seconds-edge-case', function (t) {
   t.end()
 })
 
+test('fraction toText:', function (t) {
+  const arr = [
+    ['4/10', 'four tenths'],
+    ['3/5', 'three fifths'],
+    ['1/2', 'one half'],
+    ['1/5', 'one fifth'],
+  ]
+  arr.forEach(a => {
+    const doc = nlp(a[0])
+    doc.fractions().toText()
+    t.equal(doc.text(), a[1], here + 'toText - ' + a[0])
+  })
+  t.end()
+})
+
 test('do-math:', function (t) {
   const arr = nlp('1/2').fractions().get()
   t.equal((arr[0] || {}).decimal, 0.5, here + 'do-math')


### PR DESCRIPTION
## What

Adds the missing `toText()` method to the `fractions()` view. Previously:

```js
nlp('1/2').fractions().toText() // TypeError: toText is not a function
```

The view exposed `toDecimal`, `toFraction`, `toPercentage`, `toOrdinal`, and `toCardinal`, but `toText` was missing.

## How

`toText()` spells the fraction out in words, reusing the existing `toOrdinal` convert helper (`convert/toOrdinal.js`) that the sibling methods already rely on — so it correctly produces `1/2` → "one half", `3/5` → "three fifths", `4/10` → "four tenths", including the `half`/pluralization special cases. The empty-string guard mirrors the helper's divide-by-zero handling.

## Testing

- Added a test in `tests/three/numbers/fractions.test.js` covering the spelled-out forms.
- Confirmed it fails before the change (`TypeError`) and passes after.
- `tests/three/numbers/fractions.test.js` → 54/54 pass; full numbers sweep `tests/three/numbers/*.test.js` → 379/379 pass.

Closes #1141
